### PR TITLE
Feature/box optimization improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-ForwardDiffChainRules = "c9556dd2-1aed-4cfe-8560-1557cf593001"
 Integrals = "de52edbc-65ea-441a-8357-d3a637375a31"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
@@ -26,22 +25,24 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [weakdeps]
 Clapeyron = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
 DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
+Metaheuristics = "bcdb8e00-2c21-11e9-3065-2b553b22f898"
 
 [extensions]
 ClapeyronExt = "Clapeyron"
 LangmuirDynamicQuantitiesExt = "DynamicQuantities"
+LangmuirMetaheuristicsExt = "Metaheuristics"
 
 [compat]
-BlackBoxOptim = "^0.6.2"
+BlackBoxOptim = "^0.6.5"
 ChainRulesCore = "1"
 Clapeyron = "0.6"
 CommonSolve = "0.2.4"
 DynamicQuantities = "1"
 ForwardDiff = "^0.10, 1"
-ForwardDiffChainRules = "0.2, 0.3"
 Integrals = "4, 5"
 LinearAlgebra = "1"
 LogExpFunctions = "^0.3.24"
+Metaheuristics = "3"
 NLSolvers = "0.5"
 PolyLog = "^2.5.0"
 Polynomials = "4"
@@ -57,4 +58,4 @@ julia = "1.10"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Clapeyron"]
+test = ["Test"]

--- a/ext/LangmuirMetaheuristicsExt.jl
+++ b/ext/LangmuirMetaheuristicsExt.jl
@@ -1,0 +1,59 @@
+module LangmuirMetaheuristicsExt
+using Langmuir
+using Metaheuristics
+using Langmuir.CommonSolve
+
+function CommonSolve.solve(prob::IsothermFittingProblem{M, L, DL, DC, X, LB, UB, F},
+alg::Metaheuristics.AbstractAlgorithm) where {M, L, DL, DC, X, LB, UB, F}
+    
+    Ðₗ = prob.LoadingData
+    Ðₕ = prob.CalorimetricData
+
+    p = Langmuir.pressure(Ðₗ)
+    l = Langmuir.loading(Ðₗ)
+    T = Langmuir.temperature(Ðₗ)
+    σ² = Langmuir.variance(Ðₗ)
+    _0 = zero(Base.promote_eltype(p,l,T,σ²))
+    _1 = one(_0)
+    n_max,i_max = findmax(l)
+    n_max += 3*sqrt(σ²[i_max]) #maximum bound
+    ℓ(θ) = let prob = prob, p = p, l = l, T = T, n_max = n_max,ub = prob.ub, lb = prob.lb
+
+        _θ = copy(θ)
+        _θ .= Langmuir.auto_interp_eval.(θ,lb,ub)
+
+        # Reconstruct full model from fittable parameters
+        model = Langmuir.from_vec_fittable(prob.IsothermModel, _θ, prob.model_template, prob.fittable)
+
+        ℓr = zero(eltype(model))
+        
+        for (pᵢ, nᵢ, Tᵢ, σ²ᵢ) in zip(p, l, T, σ²)
+            n̂ᵢ = loading(model, pᵢ, Tᵢ) #Predicted loading
+            ℓrᵢ = iszero(σ²ᵢ) ? prob.loss(nᵢ - n̂ᵢ) : prob.loss(nᵢ - n̂ᵢ)/σ²ᵢ #if zero variance, just use the loss
+            #!isfinite(ℓrᵢ) && (ℓrᵢ += 1e100) #if not finite, add a big number
+            #n̂ᵢ < 0 && (ℓrᵢ *= exp(100*abs(n̂ᵢ))) #if loading is negative, add a penalty multiplier, proportional to the negativity
+            #n̂ᵢ > n_max && (ℓrᵢ *= exp(abs(n_max - n̂ᵢ))) #if loading is greater than maximum loading, also add penalty
+            ℓr += ℓrᵢ
+        end
+
+        return ℓr
+
+    end
+
+    x0 = Langmuir.auto_interp_inv.(prob.x0,prob.lb,prob.ub)
+    Metaheuristics.set_user_solutions!(alg, x0, ℓ);
+    bounds = Metaheuristics.boxconstraints(lb = zeros(length(x0)), ub =ones(length(x0)))
+    result = Metaheuristics.optimize(ℓ,bounds,alg)
+
+    x_best = Metaheuristics.minimizer(result)
+
+    loss_opt_M = Metaheuristics.minimum(result)
+
+    θ_best = similar(x_best)
+    θ_best .= Langmuir.auto_interp_eval.(x_best,prob.lb,prob.ub)
+
+    # Reconstruct full model from fitted fittable parameters
+    return loss_opt_M, Langmuir.from_vec_fittable(prob.IsothermModel, θ_best, prob.model_template, prob.fittable)
+end
+
+end

--- a/src/Langmuir.jl
+++ b/src/Langmuir.jl
@@ -13,7 +13,7 @@ import CommonSolve
 using BlackBoxOptim
 using Printf
 using PrettyTables
-using ForwardDiffChainRules
+#using ForwardDiffChainRules
 import ChainRulesCore
 import Polynomials
 using RecipesBase

--- a/src/methods/fit.jl
+++ b/src/methods/fit.jl
@@ -49,14 +49,15 @@ Base.@kwdef struct DEIsothermFittingSolver <: IsothermFittingSolver
     time_limit::Float64 = 20.0
     verbose::Bool = false
     logspace::Bool = true
+    seed::Int = 314159265358
 end
 
 Base.@kwdef struct NewtonIsothermFittingSolver <: IsothermFittingSolver
     logspace::Bool = false
 end
 
-Base.@kwdef struct NLSolversIsothermFittingSolver <: IsothermFittingSolver
-    max_iter::Int = 1000
+Base.@kwdef struct NLSolversIsothermFittingSolver{T} <: IsothermFittingSolver
+    method::T = NLSolvers.BFGS()
     verbose::Bool = false
     logspace::Bool = false
     ftol::Float64 = 1e-8
@@ -69,6 +70,162 @@ end
 
 end =#
 
+#from (0,1) to (lb,ub)
+function auto_interp_eval(_x,_lb,_ub,logspace = false)
+    x,lb,ub = promote(_x,_lb,_ub)
+    
+    x = clamp(x,zero(x),one(x))
+    if isinf(lb) && !isinf(ub)
+        #=
+        from -Inf to ub
+        at x = 0 -> y = -Inf
+        at x = 1 -> y = ub
+        =#
+        maybe_logspace_ub = log2(abs(ub)) < -16
+        if logspace || maybe_logspace_ub
+            u = log2(x)
+            x̄ =  1/(1 - u)
+        else
+            x̄ =  x
+        end
+        w = max(zero(ub),-2*ub)
+        y = -1/x̄  + (ub + w)*x̄ + 1 - w
+    elseif isinf(lb) && isinf(ub)
+        #=
+        from -Inf to Inf
+        at x = 0 -> y = -Inf
+        at x = 1 -> y = Inf
+        =#
+        y = tanpi(x - 0.5)
+    elseif !isinf(lb) && isinf(ub)
+        #=
+        from lb to Inf
+        at x = 0 -> y = lb
+        at x = 1 -> y = Inf
+        =#
+        maybe_logspace_lb = log2(abs(lb)) < -16
+        w = min(zero(lb),-2*lb)
+        if logspace || maybe_logspace_lb
+            u = log2(x)
+            x̄ =  1 - 1/(1 - u)
+        else
+            x̄ =  1 - x
+        end
+        y = 1/x̄ + (lb + w)*x̄ - 1 - w
+    else
+        maybe_log_positive = (0 < abs(lb) < max(ub,ub - 2*lb)) && max(ub,ub - 2*lb)/abs(lb) > 100
+        maybe_log_negative = (min(lb,lb - 2*ub) < -abs(ub) < 0) && -abs(ub)/min(lb,lb - 2*ub) > 100
+        if logspace || maybe_log_positive || maybe_log_negative
+            if iszero(ub) #[ub,0]
+                lny = (1 - x)*log2(-lb + 1)
+                y = 1 - exp2(lny)
+            elseif iszero(lb) #[0,ub]
+                lny = x*log2(ub + 1)
+                y = 1exp2(lny) - 1
+            else #[lb,ub]
+                w = abs(lb) > abs(ub) ? min(zero(ub),-2*ub) : max(zero(lb),-2*lb)
+                ratio = (ub + w)/(lb + w)
+                y = (lb + w)*exp2(x*log2(ratio)) - w
+            end
+        else
+            y = x*ub + (1 - x)*lb
+        end
+    end
+    return y
+end
+
+#from (lb,ub) to (0,1)
+function auto_interp_inv(_y, _lb, _ub, logspace = false)
+    y,lb,ub = promote(_y,_lb,_ub)
+    y = clamp(y,lb,ub)
+    @assert lb < ub "invalid bounds, lb is equal or greater than ub"
+    if isinf(lb) && !isinf(ub)
+        maybe_logspace_ub = log2(abs(ub)) < -16
+        w = max(zero(ub),-2*ub)
+        #0 = -1/x̄  + (ub + w)*x̄ + 1 - w - y
+        #0 = -1/x̄  + (ub + w)*x̄ + 1 - w - y
+        #0 =   -1  + (ub + w)*x̄^2 + (1 - w - y)*x̄
+        a = (ub + w)
+        b = (1 - w - y)
+        c = -1
+        if !iszero(a)
+            disc2 = b^2 - 4*a*c
+            disc = sqrt(disc2)
+            x̄₁ = (-b + disc) / (2*a)
+            x̄₂ = (-b - disc) / (2*a)
+            x̄ = (0 < x̄₁ < 1) ? x̄₁ : x̄₂
+        else
+            x̄ = -c/b
+        end
+        if logspace || maybe_logspace_ub
+            #=
+            x̄ =  1/(1 - log(x))
+            =#
+            x = exp2(1 - 1/x̄)
+        else
+            x = x̄
+        end
+    elseif isinf(lb) && isinf(ub)
+        # y = tanpi(x - 0.5)  →  x = atan(y)/π + 0.5
+        x = atan(y)/π + 0.5
+    elseif !isinf(lb) && isinf(ub)
+        maybe_logspace_lb = log2(abs(lb)) < -16
+        w = min(zero(lb),-2*lb)
+        #y = 1/x̄ + (lb + w)*x̄   - 1 - w
+        #0 = 1/x̄ + (ub + w)*x̄   - 1 - w - y
+        #0 = 1 +   (ub + w)*x̄^2 + (-1 - w - y)*x̄
+        a = (lb + w)
+        b = (-1 - w - y)
+        c = 1
+        if !iszero(a)
+            disc2 = b^2 - 4*a*c
+            disc = sqrt(disc2)
+            x̄₁ = (-b + disc) / (2*a)
+            x̄₂ = (-b - disc) / (2*a)
+            x̄ = (0 < x̄₁ < 1) ? x̄₁ : x̄₂
+        else
+            x̄ = -c/b
+        end
+        u = 1 - x̄
+        if logspace || maybe_logspace_lb
+            #=x̄ =  1 - 1/(1 - log(x))
+            u = 1/(1 - log(x))
+            =#
+            x = exp2(1 - 1/u)
+        else
+            x = u
+        end
+    else
+        maybe_log_positive = (0 < abs(lb) < max(ub,ub - 2*lb)) && max(ub,ub - 2*lb)/abs(lb) > 100
+        maybe_log_negative = (min(lb,lb - 2*ub) < -abs(ub) < 0) && -abs(ub)/min(lb,lb - 2*ub) > 100
+        
+        
+        if logspace || maybe_log_positive || maybe_log_negative
+            if iszero(ub) #[ub,0]
+                #=
+                lny = (1 - x)*log2(-lb + 1)
+                y = 1 - exp2((1 - x)*log2(-lb + 1))
+                log2(1 - y) = (1 - x)*log2(-lb + 1)
+                =#
+                u = log2(1 - y)/log2(-lb + 1)
+                x = 1 - u
+            elseif iszero(lb) #[0,ub]
+                x = log2(y + 1)/log2(ub + 1)
+                #lny = x*log2(ub + 1)
+                #y = exp2(lny) - 1
+            else
+                w = abs(lb) > abs(ub) ? min(zero(ub),-2*ub) : max(zero(lb),-2*lb)
+                ratio = (ub + w)/(lb + w)
+                x = log2((y + w)/(lb + w))/log2(ratio)
+            end
+        else
+            # y = x*ub + (1-x)*lb  →  x = (y - lb)/(ub - lb)
+            x = (y - lb) / (ub - lb)
+        end
+    end
+    return x
+end
+
 function CommonSolve.solve(prob::IsothermFittingProblem{M, L, DL, DC, X, LB, UB, F},
 alg::DEIsothermFittingSolver) where {M, L, DL, DC, X, LB, UB, F}
     
@@ -79,18 +236,15 @@ alg::DEIsothermFittingSolver) where {M, L, DL, DC, X, LB, UB, F}
     l = loading(Ðₗ)
     T = temperature(Ðₗ)
     σ² = variance(Ðₗ)
-    lb_sign = sign.(nextfloat.(prob.lb)) #Assumes that parameters are either > 0 or < 0.
-
+    _0 = zero(Base.promote_eltype(p,l,T,σ²))
+    _1 = one(_0)
     n_max,i_max = findmax(l)
     n_max += 3*sqrt(σ²[i_max]) #maximum bound
-    ℓ(θ) = let prob = prob, lb_sign = lb_sign, p = p, l = l, T = T, is_logspace = alg.logspace, n_max = n_max
+    ℓ(θ) = let prob = prob, p = p, l = l, T = T, is_logspace = alg.logspace, n_max = n_max,ub = prob.ub, lb = prob.lb
 
         _θ = copy(θ)
+        _θ .= auto_interp_eval.(θ,lb,ub,is_logspace)
 
-        if is_logspace
-            _θ .= lb_sign .* exp.(θ)
-        end
-        
         # Reconstruct full model from fittable parameters
         model = from_vec_fittable(prob.IsothermModel, _θ, prob.model_template, prob.fittable)
 
@@ -99,9 +253,9 @@ alg::DEIsothermFittingSolver) where {M, L, DL, DC, X, LB, UB, F}
         for (pᵢ, nᵢ, Tᵢ, σ²ᵢ) in zip(p, l, T, σ²)
             n̂ᵢ = loading(model, pᵢ, Tᵢ) #Predicted loading
             ℓrᵢ = iszero(σ²ᵢ) ? prob.loss(nᵢ - n̂ᵢ) : prob.loss(nᵢ - n̂ᵢ)/σ²ᵢ #if zero variance, just use the loss
-            !isfinite(ℓrᵢ) && (ℓrᵢ += 1e100) #if not finite, add a big number
-            n̂ᵢ < 0 && (ℓrᵢ *= exp(10*abs(n̂ᵢ))) #if loading is negative, add a penalty multiplier, proportional to the negativity
-            n̂ᵢ > n_max && (ℓrᵢ *= exp(abs(n_max - n̂ᵢ))) #if loading is greater than maximum loading, also add penalty
+            #!isfinite(ℓrᵢ) && (ℓrᵢ += 1e100) #if not finite, add a big number
+            #n̂ᵢ < 0 && (ℓrᵢ *= exp(100*abs(n̂ᵢ))) #if loading is negative, add a penalty multiplier, proportional to the negativity
+            #n̂ᵢ > n_max && (ℓrᵢ *= exp(abs(n_max - n̂ᵢ))) #if loading is greater than maximum loading, also add penalty
             ℓr += ℓrᵢ
         end
 
@@ -109,53 +263,28 @@ alg::DEIsothermFittingSolver) where {M, L, DL, DC, X, LB, UB, F}
 
     end
 
-
-    if alg.logspace
-        x0 = log.(sign.(prob.x0) .* prob.x0)
-        lb = log.(sign.(nextfloat.(prob.lb)) .* nextfloat.(prob.lb))
-        ub = log.(sign.(prevfloat.(prob.ub)) .* prevfloat.(prob.ub))
+    x0 = auto_interp_inv.(prob.x0,prob.lb,prob.ub,alg.logspace)
+    seed0 = BlackBoxOptim.Random.seed!()
+    BlackBoxOptim.Random.seed!(alg.seed)
     
-        # Ensure lb and ub are mutable arrays
-        lb = collect(lb)
-        ub = collect(ub)
-    
-        # Swap lb and ub in logspace if the parameter is between -Inf and 0
-        for i in eachindex(lb)
-            if lb[i] > ub[i]
-                lb[i], ub[i] = ub[i], lb[i]
-            end
-        end
-        
-    else
-
-        lb = nextfloat.(prob.lb)
-        ub = prevfloat.(prob.ub)
-        x0 = prob.x0 
-    end
-
-
     result = BlackBoxOptim.bboptimize(ℓ, x0; 
-    SearchRange = [(lb[i], ub[i]) for i in eachindex(lb)],
-    PopulationSize = alg.population_size,
-    MaxTime = alg.time_limit,
-    MaxSteps = alg.max_steps,
-    TraceMode = ifelse(alg.verbose, :verbose, :silent))
+                                    SearchRange = [(_0, _1) for i in eachindex(x0)],
+                                    PopulationSize = alg.population_size,
+                                    MaxTime = alg.time_limit,
+                                    MaxSteps = alg.max_steps,
+                                    TraceMode = ifelse(alg.verbose, :verbose, :silent))
 
-    opt_M = BlackBoxOptim.best_candidate(result)
+    BlackBoxOptim.Random.seed!(seed0)
+
+    x_best = BlackBoxOptim.best_candidate(result)
 
     loss_opt_M = BlackBoxOptim.best_fitness(result)
 
-    opt_θ = similar(opt_M)
-
-    if alg.logspace
-        opt_θ .= lb_sign .* exp.(opt_M)
-    else
-        opt_θ = opt_M
-    end
+    θ_best = similar(x_best)
+    θ_best .= auto_interp_eval.(x_best,prob.lb,prob.ub,alg.logspace)
 
     # Reconstruct full model from fitted fittable parameters
-    return loss_opt_M, from_vec_fittable(prob.IsothermModel, opt_θ, prob.model_template, prob.fittable)
-
+    return loss_opt_M, from_vec_fittable(prob.IsothermModel, θ_best, prob.model_template, prob.fittable)
 end
 
 function CommonSolve.solve(solver::NewtonIsothermFittingSolver)
@@ -203,7 +332,7 @@ alg::NLSolversIsothermFittingSolver) where {M, L, DL, DC, X, LB, UB, F}
     )
     
     # Use L-BFGS method - for bounded optimization, use through TrustRegion/ActiveBox
-    method = NLSolvers.BFGS()
+    method = alg.method
     
     # Create objective with automatic differentiation
     obj = ADScalarObjective(loss_fn, x0)
@@ -222,7 +351,7 @@ alg::NLSolversIsothermFittingSolver) where {M, L, DL, DC, X, LB, UB, F}
 end
 
 function fit(prob::IsothermFittingProblem{M, L, DL, DC, X, LB, UB, F},
-    alg::IsothermFittingSolver) where {M, L, DL, DC, X, LB, UB, F}
+    alg) where {M, L, DL, DC, X, LB, UB, F}
     
     return solve(prob, alg)
 
@@ -260,7 +389,7 @@ loss, model = fit(Freundlich, data, solver=NLSolversIsothermFittingSolver())
 function fit(::Type{M}, data::AdsIsoTData; 
              fittable::Union{Nothing,AbstractVector{Bool}}=nothing,
              loss=abs2,
-             solver::IsothermFittingSolver=DEIsothermFittingSolver()) where M <: IsothermModel
+             solver=DEIsothermFittingSolver()) where M <: IsothermModel
     
     prob = IsothermFittingProblem(M, data, loss; fittable=fittable)
     return fit(prob, solver)

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -42,6 +42,13 @@ function IsothermBoundsError(::Type{M},lb,ub,datai,i) where M <: IsothermModel
     throw(ArgumentError(lazy"$(nameof(M)): value for the field `$symbol` $(d)is out of the parameter bounds: ($lb <= $datai <= $ub) == false"))
 end
 
+@generated function ___unsafe_build_model(::Type{M},p) where M <: IsothermModel
+    N = model_length(M)
+    ex = Expr(:tuple, [:(p[$i]) for i in 1:N]...)
+    MM = M.name.name
+    return :($MM($(ex)...))
+end
+
 function from_vec(m::IsothermModel,x)
     return from_vec(typeof(m),x,true)
 end
@@ -57,9 +64,10 @@ function from_vec(::Type{M},p,check) where {M <: IsothermModel}
 end
 
 function from_vec(::Type{M},p,check) where M <: IsothermModel{T} where T
-    data = ntuple(i -> T(p[i]), model_length(M))
+    TT = Base.promote_type(eltype(p),eltype(M))
+    data = ntuple(i -> TT(p[i]), model_length(M))
     check && isotherm_checkbounds(M,data)
-    return M(data...)
+    return ___unsafe_build_model(M,data)
 end
 
 function to_vec!(model::IsothermModel,x)
@@ -101,13 +109,13 @@ end
 Reconstruct a model from fittable parameters `x_fit` and fixed parameters from `model_template`.
 The `fittable` vector indicates which parameters are fittable (true) vs fixed (false).
 """
-function from_vec_fittable(::Type{M}, x_fit, model_template::M, fittable::AbstractVector{Bool}) where M <: IsothermModel
+function from_vec_fittable(::Type{M}, x_fit::AbstractVector{TF}, model_template::M, fittable::AbstractVector{Bool}) where {M <: IsothermModel,TF}
     length(fittable) == model_length(M) || throw(ArgumentError("fittable vector length must match number of model parameters"))
     fittable_indices = findall(fittable)
     fixed_indices = findall(.!fittable)
     
     # Create full parameter vector with eltype that can handle dual numbers
-    T_full = promote_type(eltype(x_fit), eltype(model_template))
+    T_full = Base.promote_eltype(x_fit, model_template)
     x_full = Vector{T_full}(undef, model_length(M))
     
     # Fill in fittable parameters

--- a/src/models/quadratic.jl
+++ b/src/models/quadratic.jl
@@ -52,6 +52,8 @@ function loading(model::Quadratic, p, T)
     return M*(Ka + 2.0*Kb*p)*p/(_1 + p*(Ka + Kb*p))
 end
 
+henry_coefficient(model::Quadratic, T) = model.M*model.K₀a*exp(-model.Ea/(Rgas(model)*T))
+
 function pressure_impl(model::Quadratic, Π, T, ::typeof(sp_res))
     K₀a, K₀b, M, Ea, Eb = model.K₀a, model.K₀b, model.M, model.Ea, model.Eb
     Ka = K₀a*exp(-Ea/(Rgas(model)*T))
@@ -60,71 +62,45 @@ function pressure_impl(model::Quadratic, Π, T, ::typeof(sp_res))
     return -0.5*Kab + sqrt(0.25*Kab*Kab + expm1(Π/M)/Kb)
 end
 
-function x0_guess_fit(::Type{T}, data::AdsIsoTData) where T <: Quadratic
-    # Original implementation - commented out due to numerical instability
-    #=
-    #l*(1 + p*(Ka + Kb*p)) = M*(Ka*p + 2*Kb*p*p)
-    #p*Ka*l + Kb*p*p*l - M*Ka*p - 2*M*Kb*p*p = -l
-    #-p*Ka*l - Kb*p*p*l + M*Ka*p + 2*M*Kb*p*p = l
-    #-Ka*(p*l) -Kb*(p*p*l) + M*Ka*(p) + 2*M*Kb*(p*p) = l
+saturated_loading(model::Quadratic, T) = 2*model.M
 
-    # Split data by temperature
-    Ts, l_p = split_data_by_temperature(data)
+function x0_guess_fit(::Type{Q}, data::AdsIsoTData) where Q <: Quadratic
 
-    # Initialize vectors for Ka, Kb, and M values
-    Kas = Vector{eltype(Ts)}(undef, length(l_p))
-    Kbs = Vector{eltype(Ts)}(undef, length(l_p))
-    Ms = Vector{eltype(Ts)}(undef, length(l_p))
-   
-    # Perform fitting for each (l, p) tuple
-    for i in 1:length(l_p)
-        l_i, p_i = l_p[i]
-        Kaneg, Kbneg, MKa, MKb2 = hcat(p_i .* l_i, p_i .* p_i .* l_i, p_i, p_i .* p_i) \ l_i
-
-        Ka = abs(Kaneg)
-        Kb = abs(Kbneg)
-        Ma = MKa / Ka
-        Mb = abs(0.5 * MKb2 / Kb)
-        Ms[i] = 0.5 * (Ma + Mb)
-        Kas[i] = Ka
-        Kbs[i] = Kb
-    end
-
-    M = sum(Ms)/length(Ms) #Mean of all values
-
-    _1 = one(eltype(Ts))
-    _1s = ones(eltype(Ts), length(Ts))
-
-    if length(l_p) > 1
-        logKa, Ea = hcat(_1s, _1s./ (Rgas(T).*Ts)) \ log.(Kas)
-        Ka = exp(logKa)
-        logKb, Eb = hcat(_1s, _1s./(Rgas(T).*Ts)) \ log.(Kbs)
-        Kb = exp(logKb)
-    else
-        Ka = first(Kas)
-        Kb = first(Kbs)
-        Ea = _1
-        Eb = _1
-    end
-
-    return T(abs(Ka), abs(Kb), M, -abs(Ea), -abs(Eb))
-    =#
-
-    # Simplified approach: Use Langmuir fit as initial guess for both sites
-    # This provides more stable initial values than trying to fit 5 parameters independently
+    # Simplified approach: Use Langmuir fit as initial guess for M,K0a,Ea
     langmuir_model = x0_guess_fit(LangmuirS1, data)
-    M = langmuir_model.M
-    K₀ = langmuir_model.K₀
-    E = langmuir_model.E
-    
-    # Use the same affinity and energy for both Ka and Kb
-    # Set Kb to be smaller (typically the quadratic term is a smaller correction)
-    K₀a = K₀
-    K₀b = K₀ * 0.1  # 10% of the primary affinity
-    Ea = E
-    Eb = E
-    
-    return T(K₀a, K₀b, M, Ea, Eb)
+    M = langmuir_model.M*0.5
+    K₀a = langmuir_model.K₀*2
+    Ea = langmuir_model.E    
+    p = pressure(data)
+    T = temperature(data)
+    l = loading(data)
+    RT_inv = @. 1/(Rgas(1.0)*T)
+    Ka = @. K₀a*exp(-Ea*RT_inv)
+
+    #=
+    l*(_1 + p*(Ka + Kb*p)) = M*(Ka + 2.0*Kb*p)*p
+    l*(_1 + p*Ka + Kb*p*p) = M*(Ka*p * Kb*p*p)
+    l + l*p*Ka + l*Kb*p*p - M*Ka*p - 2*M*Kb*p*p = 0
+    l*Kb*p*p - 2*M*Kb*p*p = -(l + l*p*Ka - M*Ka*p)
+    l*Kb - 2*M*Kb= -(l + l*p*Ka - M*Ka*p) ./ p*p
+    Kb= -(l + l*p*Ka - M*Ka*p) ./ p*p / (l - 2M)
+    =#
+    Kb =  @. (-l/(p*p) - (l - M)*Ka/p) /(l - 2M)
+    i = findall(x -> isfinite(x) && x > 0,Kb)
+    Kb = Kb[i]
+    RT_inv = RT_inv[i]
+    Kb .= clamp.(Kb, 1e-30, 1e15)
+    logKb = Kb
+    logKb .= log.(Kb)
+    _1s  = ones(eltype(RT_inv), length(RT_inv))
+    coeffs = hcat(_1s, RT_inv) \ logKb
+    logK₀b = coeffs[1]
+    slope = coeffs[2]
+    K₀b = exp(logK₀b)
+     Eb = -slope  # Since slope = -E, we have E = -slope
+    @show M,Ea,K₀a
+   
+    return Q(K₀a, K₀b, M, Ea, Eb)
 end
 
 export Quadratic

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -6,7 +6,7 @@
 
 """
 
-@recipe function f(model::IsothermModel, T::Number, p_range::Tuple{<:Number, <:Number}; npoints = 100)
+RecipesBase.@recipe function f(model::IsothermModel, T::Number, p_range::Tuple{<:Number, <:Number}; npoints = 100)
     # --- Scientific Plot Defaults ---
     # Plot Size and Resolution
     #width = 500 # width in pixels
@@ -56,7 +56,7 @@
     model_name = typeof(model).name.name
     label --> Printf.@sprintf("%s, T = %.2f K", model_name, T) 
 
-    @series begin
+    RecipesBase.@series begin
         
     # Return x and y data for the series
     seriestype := :line
@@ -68,7 +68,7 @@
     end
 
 
-@recipe function f(data::AdsIsoTData, T::Number) # T is now a mandatory Number
+RecipesBase.@recipe function f(data::AdsIsoTData, T::Number) # T is now a mandatory Number
     # --- Scientific Plot Defaults ---
     #width = 500
     #size --> (width, Int(round(width/ 1.618))) # Golden ratio
@@ -108,7 +108,7 @@
     p_for_T = temp_specific_data_all[idx][2] # pressure is the second element
 
     # Define the series for plotting
-    @series begin
+    RecipesBase.@series begin
         seriestype := :scatter # Plot data as points
         markersize --> 4
         markerstrokewidth --> 0.5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ import Langmuir: gibbs_excess_free_energy, activity_coefficient
 import Langmuir: IsothermFittingProblem, DEIsothermFittingSolver
 using Test
 import Langmuir: R̄
+import Metaheuristics
 
 #we test that definitions of loading and sp_res are consistent.
 
@@ -64,15 +65,16 @@ end
         l = map(pT -> abs(loading(quad_, pT[1], pT[2]) + σ*randn()), eachrow(pt_))
         d = isotherm_data(P, l, T)
 
-        x0 = to_vec(x0_guess_fit(Quadratic, d))
-        lb = [1e-35, 1e-35, 1e-29, -80_000., -80_000.]
-        ub = [1e-3, 1e-3, 100., -5_000., -5_000.]
+        x0 = Langmuir.to_vec(Langmuir.x0_guess_fit(Quadratic, d))
+        lb = [0.0, 0.0, 0.0, -80_000., -80_000.]
+        lb = [0.0,0.0,0.0,-Inf,-Inf]
+        ub = [1e-3, 1e-3, 100., 0., -5_000.]
+        ub = [1.,1.,100.0,-5000.0,-5000.0]
         fittable = trues(5)
-        model_template = x0_guess_fit(Quadratic, d)
+        model_template = Langmuir.x0_guess_fit(Quadratic, d)
         prob = IsothermFittingProblem(Quadratic{eltype(d)}, d, nothing, abs2, x0, lb, ub, fittable, model_template) #Bounds have to be manually tweaked. Default interval is too large
         alg = DEIsothermFittingSolver(max_steps = 500, logspace = true)
-        loss_fit, fitted_isotherm = fit(prob, alg)
-
+        loss_fit, fitted_isotherm = fit(prob, Metaheuristics.ECA())
         @test (abs(sqrt(loss_fit/size(l, 1)) - σ)/σ)*100.0 < 10.0 #relative error smaller than 10% 
     end
 
@@ -287,6 +289,23 @@ end
     #Γ_chem = loading(prob_mix, solver = solver_chem)
     #Γ_fug = loading(prob_mix, solver = solver_fug)
     #@test Γ_chem ≈ Γ_fug rtol=1e-4
+end
+
+cases = [(-Inf, 1.0), (-Inf, Inf), (0.5, Inf), (1.0, 200.0), (1.0, 1.5),(-Inf,0.0),(-Inf,-1.0),(0.0,Inf),(-1.0,Inf),(-10.0,Inf),(-1.0,200)]
+
+
+@testset "misc" begin
+    @testset "auto_interp" begin
+        for (lb,ub) in cases
+            for x in range(0.01,0.99,100)
+                for logspace in (false,true)
+                    yy = Langmuir.auto_interp_eval(x,lb,ub,logspace)
+                    xx = Langmuir.auto_interp_inv(yy,lb,ub,logspace)
+                    @test x ≈ xx atol = 1e-10
+                end
+            end
+        end
+    end
 end
 
 


### PR DESCRIPTION
this PR is mainly to address the constant and random CI fails. The main culprit for the randomness is that `BlackBoxOptim` does not accept a custom random seed as input, so adding a  `Random.seed!(alg.seed)` allows to get the same result each time.

Now, to the hard part, the optimization CI fails. i wrote a custom boxing algorithm that transforms from [lb,ub] to [0,1] (and back), with support for infinities, logspace with bounds of different signs, etc. One improvement is that the boxing algorithm detects if logspace is useful or not, and applies it automatically, so no `logspace` keyword is needed anymore, in principle. This change fixed the loss fails with the `Langmuir` model and the `Freundlich` model with selected parameters.

The `Quadratic` model was the hardest to make it converge. i found an error in the initial guess function (M = 0.5M(langmuir)), and added the second order correction with some guards to make it relatively robust. i checked at the guess generated by the data on the fitting test, and the parameters seem reasonable. This change reduced the `loss_fit` of that test from 400 to around 21

even with the reduced `loss_fit` of the `Quadratic` test, the error was still too high to pass the condition, so i tried other optimizers. For that, i had to make `NLSolversIsothermFIttingOptimizer` work. there is a new `method` field to directly add another `NLSolvers` method. (the default is the same). Sadly, `NLSolvers.Newton()` did not work, `ActiveBox()` does not work with non-hermitian hessians and `BFGS()` did not result in an improvement over the initial point.

For that, i had to try `Metaheuristics`, so a `LangmuirMetaheuristicsExt` extension was added with support for `fit(prob::IsothermFittingProblem,alg;;Metaheuristics.AbstractOptimizer)`. Changing the fitting alg to `fit(prob,Metaheuristics.ECA())` did work.

@viniviena can you check if the changes to the optimizers result in an improvement?

